### PR TITLE
Added environment variables support for API endpoint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "directories": {},
   "scripts": {
-    "start": "export API_URL='http://localhost:5000';webpack-dev-server --open --config webpack.dev.js",
+    "start": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --quiet --ext .js --ext .jsx .",
     "test": "BABEL_ENV=test mocha --compilers js:babel-core/register ./test/**/*.spec.jsx",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "directories": {},
   "scripts": {
-    "start": "export API_URL='http://127.0.0.1:5000';webpack-dev-server --open --config webpack.dev.js",
+    "start": "export API_URL='http://localhost:5000';webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --quiet --ext .js --ext .jsx .",
     "test": "BABEL_ENV=test mocha --compilers js:babel-core/register ./test/**/*.spec.jsx",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "directories": {},
   "scripts": {
-    "start": "webpack-dev-server --open --config webpack.dev.js",
+    "start": "export API_URL='http://127.0.0.1:5000';webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --quiet --ext .js --ext .jsx .",
     "test": "BABEL_ENV=test mocha --compilers js:babel-core/register ./test/**/*.spec.jsx",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 module.exports = merge(require('./webpack.common.js'), {
@@ -7,5 +8,13 @@ module.exports = merge(require('./webpack.common.js'), {
   devServer: {
     contentBase: path.resolve(__dirname, 'public'),
     historyApiFallback: true,
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+        API_URL: JSON.stringify(process.env.API_URL)
+      },
+    })
+  ]
 });

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = merge(require('./webpack.common.js'), {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify('production'),
-        API_URL: JSON.stringify(process.env.API_URL)
+        API_URL: JSON.stringify('http://localhost:5000')
       },
     })
   ]

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -44,7 +44,8 @@ module.exports = merge(require('./webpack.common.js'), {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('production')
+        NODE_ENV: JSON.stringify('production'),
++       API_URL: JSON.stringify(process.env.API_URL)
       },
     }),
     new BundleAnalyzerPlugin({


### PR DESCRIPTION
For local development and for deployment purposes, the form needs to know where to submit and collect data from the API.

I believe an environment variable is a viable way to allow to use multiple environments, currently using the `API_URL` name which is located in the `package.json` script and set up automatically during yarn start for local development.

For deployments, the API_URL is different for staging and for production, this value is dynamically assigned on Travis-CI. The form when is built will inherit the correct values once deployed.